### PR TITLE
Fixed Arweave init for ReactJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 .npm
 
 package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -61,14 +61,7 @@ omiting the `address` parameter returns the recent feed of the requested network
 
 > For ReactJS usage:
 >
-> add an extra `default` between `Arweave` and `init` in `utils/arweave/arweave.js`
->
-> ```js
-> export const arweave = Arweave.default.init({
->  host: "arweave.net",
->  ...
-> });
-> ```
+> Modifying `utils/arweave/arweave.js` no longer required for ReactJS.
 
 # License
 This projects is licensed under the MIT license

--- a/src/utils/arweave/arweave.js
+++ b/src/utils/arweave/arweave.js
@@ -1,13 +1,16 @@
 import { InvalidArweaveAddress } from "../errors/invalidAddress.js";
 import Arweave from "arweave";
 
-export const arweave = Arweave.init({
+const arweaveConfigs = {
   host: "arweave.net",
   port: 443,
   protocol: "https",
   timeout: 20000,
   logging: false,
-});
+}
+
+export const arweave = (typeof window !== 'undefined') ? 
+  Arweave.default.init(arweaveConfigs) : Arweave.init(arweaveConfigs);
 
 
 export function _validateAddress(address) {


### PR DESCRIPTION
Added a check if global `window` exists to verify if the module is being used by a web-based API and use `default` if exists.